### PR TITLE
OSX deprecation warning: replaced OSMemoryBarrier by atomic_thread…

### DIFF
--- a/src/Barrier.cpp
+++ b/src/Barrier.cpp
@@ -34,22 +34,24 @@
 */
 
 #include "Barrier.h"
-#include <atomic>
 
-#if defined __APPLE__ && defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && __MAC_OS_X_VERSION_MIN_REQUIRED < 101200
+#if defined __APPLE__
+#if defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && __MAC_OS_X_VERSION_MIN_REQUIRED < 101200
     #include <libkern/OSAtomic.h>
+#else
+    #include <atomic>
 #endif
-
+#endif
 namespace breakfastquay {
 
 void system_memorybarrier()
 {
-#if defined __APPLE__ 
+#if defined __APPLE__
 #if defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && __MAC_OS_X_VERSION_MIN_REQUIRED < 101200
-   OSMemoryBarrier();
+    OSMemoryBarrier();
 #else
     atomic_thread_fence(std::memory_order_seq_cst);
-#endif 
+#endif
 #elif (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 1)
 
     __sync_synchronize();

--- a/src/Barrier.cpp
+++ b/src/Barrier.cpp
@@ -34,19 +34,22 @@
 */
 
 #include "Barrier.h"
+#include <atomic>
 
-#if defined __APPLE__
-#include <libkern/OSAtomic.h>
+#if defined __APPLE__ && defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && __MAC_OS_X_VERSION_MIN_REQUIRED < 101200
+    #include <libkern/OSAtomic.h>
 #endif
 
 namespace breakfastquay {
 
 void system_memorybarrier()
 {
-#if defined __APPLE__
-
-    OSMemoryBarrier();
-    
+#if defined __APPLE__ 
+#if defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && __MAC_OS_X_VERSION_MIN_REQUIRED < 101200
+   OSMemoryBarrier();
+#else
+    atomic_thread_fence(std::memory_order_seq_cst);
+#endif 
 #elif (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 1)
 
     __sync_synchronize();


### PR DESCRIPTION
Suggestion to address the OSMemoryBarrier deprecation warning. Only tested compilation. Valgrind is not entirely happy with the base commit or this branch (Illegal instruction: 4).
This would require c++11 for OSX
```
src/Barrier.cpp:48:5: error: 'OSMemoryBarrier' is deprecated: first deprecated in macOS 10.12 - Use std::atomic_thread_fence() from <atomic> instead
      [-Werror,-Wdeprecated-declarations]
    OSMemoryBarrier();
```